### PR TITLE
34 create the group page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import NavbarSignedIn from "./components/NavbarSignedIn";
 import Friends_List from "./components/Friends_List_Component";
 import ProfilePage from "./pages/ProfilePage";
 import GroupPage from "./pages/MyGroupsPage";
-import IndividualGroupPage from "./pages/IndividualGroupPage"
+import IndividualGroupPage from "./pages/IndividualGroupPage";
 import EditItem from "./components/EditItem";
 import { useState, useEffect } from "react";
 import { IUser } from "../../backend/models/userSchema";
@@ -114,7 +114,8 @@ function App() {
                 />
               }
             />
-            <Route path="/groups/:groupId" element={<IndividualGroupPage />} /> {/* added route for individual group page */}
+            <Route path="/groups/:groupId" element={<IndividualGroupPage />} />{" "}
+            {/* added route for individual group page */}
             <Route
               path="/groups"
               element={

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import NavbarSignedIn from "./components/NavbarSignedIn";
 import Friends_List from "./components/Friends_List_Component";
 import ProfilePage from "./pages/ProfilePage";
 import GroupPage from "./pages/MyGroupsPage";
+import IndividualGroupPage from "./pages/IndividualGroupPage"
 import { useState, useEffect } from "react";
 import { IUser } from "../../backend/models/userSchema";
 
@@ -107,6 +108,7 @@ function App() {
               }
             />
             <Route path="/groups" element={<GroupPage />} />
+            <Route path="/groups/:groupId" element={<IndividualGroupPage />} /> {/* added route for individual group page */}
           </Routes>
         </Box>
       </Router>

--- a/frontend/src/pages/DummyGroupPage.tsx
+++ b/frontend/src/pages/DummyGroupPage.tsx
@@ -1,6 +1,0 @@
-// Component can be deleted when whoever is working on GroupPage starts
-function DummyGroupPage() {
-  return <div>DummyGroupPage</div>;
-}
-
-export default DummyGroupPage;

--- a/frontend/src/pages/IndividualGroupPage.tsx
+++ b/frontend/src/pages/IndividualGroupPage.tsx
@@ -94,36 +94,41 @@ function IndividualGroupPage() {
         ) : group ? (
           <VStack align="stretch" spacing={4}>
             <Flex justifyContent="space-between" alignItems="center">
-              <Flex alignItems="center">
-                <Heading size="lg" marginRight="10px">{group.groupName}</Heading>
-                <Text fontSize="lg">{group.description || "No description given"}</Text>
-              </Flex>
+              <Heading size="lg" marginRight="10px">{group.groupName}</Heading>
+              <InputGroup width="300px">
+                <InputLeftElement pointerEvents="none" children={<IoSearch />} />
+                <Input placeholder="Search in group" />
+              </InputGroup>
               <HStack>
                 <IconButton icon={<IoAddCircleOutline />} aria-label="Add" />
                 <IconButton icon={<IoSettingsSharp />} aria-label="Settings" />
               </HStack>
             </Flex>
-            <InputGroup width="300px" marginY="20px">
-              <InputLeftElement pointerEvents="none" children={<IoSearch />} />
-              <Input placeholder="Search in group" />
-            </InputGroup>
-            <Box>
-              <Heading size="md">Members</Heading>
-              <VStack align="start">
-                {group.members.map((member, index) => (
-                  <Text key={index}>{member}</Text>
-                ))}
+            <Flex justifyContent="space-between">
+              <VStack align="start" spacing={4} flex="1">
+                <Box>
+                  <Heading size="md">Members</Heading>
+                  <VStack align="start">
+                    {group.members.map((member, index) => (
+                      <Text key={index}>{member}</Text>
+                    ))}
+                  </VStack>
+                </Box>
+                <Box>
+                  <Heading size="md">Created On</Heading>
+                  <Text>{new Date(group.created).toLocaleDateString()}</Text>
+                </Box>
+                <Box mt={4}>
+                  <Button as={Link} to={`/groups/edit/${group._id}`} colorScheme="teal" width="200px">
+                    Edit Group
+                  </Button>
+                </Box>
               </VStack>
-            </Box>
-            <Box>
-              <Heading size="md">Created On</Heading>
-              <Text>{new Date(group.created).toLocaleDateString()}</Text>
-            </Box>
-            <Box mt={4}>
-              <Button as={Link} to={`/groups/edit/${group._id}`} colorScheme="teal" width="200px">
-                Edit Group
-              </Button>
-            </Box>
+              <Box flex="3" paddingLeft="20px">
+                <Heading size="md">Description</Heading>
+                <Text fontSize="lg">{group.description || "No description given"}</Text>
+              </Box>
+            </Flex>
             <Box mt={8}>
               <Heading size="md">Baskets Component</Heading>
               <Text mt={2}>This is where the Baskets component will be placed.</Text>

--- a/frontend/src/pages/IndividualGroupPage.tsx
+++ b/frontend/src/pages/IndividualGroupPage.tsx
@@ -91,24 +91,29 @@ function IndividualGroupPage() {
         >
           Go Back
         </Button>
-        <Flex alignItems="center" flexWrap="wrap" mt={{ base: 4, md: 0 }}>
-          <InputGroup width={{ base: "100%", md: "300px" }} marginRight="20px">
+        <Flex
+          alignItems="right"
+          flexDirection={{ base: "column", md: "row" }}
+          mt={{ base: 4, md: 0 }}
+        >
+          <Button
+            onClick={() => console.log("Send Invite clicked")}
+            bg="teal"
+            color="white"
+            _hover={{ bg: "teal" }}
+            marginRight={{ md: "10px" }}
+            mb={{ base: 2, md: 0 }}
+            alignSelf={{ base: "flex-end", md: "center" }}
+          >
+            Send Invite
+          </Button>
+          <InputGroup width={{ base: "100%", md: "300px" }}>
             <InputLeftElement pointerEvents="none" children={<IoSearch />} />
             <Input
               placeholder="Search in group"
               backgroundColor="rgba(255, 255, 255, 0.8)"
             />
           </InputGroup>
-          <Button
-            onClick={() => console.log("Send Invite clicked")}
-            bg="teal"
-            color="white"
-            _hover={{ bg: "teal" }}
-            marginRight="10px"
-            mt={{ base: 2, md: 0 }}
-          >
-            Send Invite
-          </Button>
         </Flex>
       </Flex>
 
@@ -209,9 +214,7 @@ function IndividualGroupPage() {
             </Box>
             <Box mt={8} width="99%">
               <Heading size="md">Baskets Component</Heading>
-              <Text mt={2}>
-                This is where the Baskets component will go!
-              </Text>
+              <Text mt={2}>This is where the Baskets component will go!</Text>
               <Box overflowY="auto" maxHeight="300px" mt={4}>
                 {/* Replace with actual basket items */}
                 <VStack spacing={4} align="stretch">

--- a/frontend/src/pages/IndividualGroupPage.tsx
+++ b/frontend/src/pages/IndividualGroupPage.tsx
@@ -12,23 +12,14 @@ import {
   Input,
   InputGroup,
   InputLeftElement,
+  Divider,
 } from "@chakra-ui/react";
-import { IoArrowBack, IoSearch, IoAddCircleOutline, IoSettingsSharp } from "react-icons/io5";
-//import "../styles/GroupPage.css";
-
-export interface Group {
-  groupName: string;
-  _id: string;
-  privateGroup: boolean;
-  description: string;
-  members: string[];
-  baskets: string[];
-  created: Date;
-}
+import { IoArrowBack, IoSearch, IoSettingsSharp } from "react-icons/io5";
+import { IGroup } from "../../../backend/models/groupSchema";
 
 function IndividualGroupPage() {
   const { groupId } = useParams<{ groupId: string }>();
-  const [group, setGroup] = useState<Group | null>(null);
+  const [group, setGroup] = useState<IGroup | null>(null);
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
 
@@ -65,18 +56,29 @@ function IndividualGroupPage() {
         padding="10px 20px"
         borderBottom="2px solid"
         borderColor="rgba(100, 100, 100, 0.8)"
-        bgGradient="linear(to-r, rgba(0,0,0,0) 10%, var(--col-secondary) 30%, var(--col-secondary) 70%, rgba(0,0,0,0) 90%)"
+        bgGradient="linear(t-b, rgba(0,0,0,0) 10%, var(--col-secondary) 30%, var(--col-secondary) 70%, rgba(0,0,0,0) 90%)"
       >
+        <Button onClick={() => navigate('/groups')} variant="link" leftIcon={<IoArrowBack />}>
+          Go Back
+        </Button>
         <Flex alignItems="center">
-          <IconButton
-            icon={<IoArrowBack />}
-            aria-label="Go Back"
-            onClick={() => navigate('/groups')}
+          <InputGroup width="300px" marginRight="20px">
+            <InputLeftElement pointerEvents="none" children={<IoSearch />} />
+            <Input
+              placeholder="Search in group"
+              backgroundColor="rgba(255, 255, 255, 0.8)"
+            />
+          </InputGroup>
+          <Button
+            onClick={() => console.log('Send Invite clicked')}
+            bg="teal"
+            color="white"
+            _hover={{ bg: "teal" }}
             marginRight="10px"
-          />
-          <Button onClick={() => navigate('/groups')} variant="link" leftIcon={<IoArrowBack />}>
-            Go Back
+          >
+            Send Invite
           </Button>
+          <IconButton icon={<IoSettingsSharp />} aria-label="Settings" />
         </Flex>
       </Flex>
 
@@ -86,50 +88,74 @@ function IndividualGroupPage() {
         padding="20px"
         flex="1"
         overflowY="auto"
+        alignItems="center"
       >
         {loading ? (
           <Box padding="20px">
             Loading...
           </Box>
         ) : group ? (
-          <VStack align="stretch" spacing={4}>
-            <Flex justifyContent="space-between" alignItems="center">
-              <Heading size="lg" marginRight="10px">{group.groupName}</Heading>
-              <InputGroup width="300px">
-                <InputLeftElement pointerEvents="none" children={<IoSearch />} />
-                <Input placeholder="Search in group" />
-              </InputGroup>
-              <HStack>
-                <IconButton icon={<IoAddCircleOutline />} aria-label="Add" />
-                <IconButton icon={<IoSettingsSharp />} aria-label="Settings" />
-              </HStack>
-            </Flex>
-            <Flex justifyContent="space-between">
-              <VStack align="start" spacing={4} flex="1">
-                <Box>
-                  <Heading size="md">Members</Heading>
-                  <VStack align="start">
-                    {group.members.map((member, index) => (
-                      <Text key={index}>{member}</Text>
-                    ))}
-                  </VStack>
-                </Box>
-                <Box>
-                  <Heading size="md">Created On</Heading>
-                  <Text>{new Date(group.created).toLocaleDateString()}</Text>
-                </Box>
-                <Box mt={4}>
-                  <Button as={Link} to={`/groups/edit/${group._id}`} colorScheme="teal" width="200px">
+          <>
+            <Box
+              width="99%"
+              padding="20px"
+              borderWidth="1px"
+              borderRadius="md"
+              backgroundColor="rgba(255, 255, 255, 0.8)"
+            >
+              <VStack align="stretch" spacing={4}>
+                <Flex justifyContent="center" alignItems="center" position="relative">
+                  <Heading size="2xl" textAlign="center">{group.groupName}</Heading>
+                  <Button
+                    bg="gray.500"
+                    color="white"
+                    _hover={{ bg: "gray.500" }}
+                    position="absolute"
+                    right="0"
+                  >
                     Edit Group
                   </Button>
-                </Box>
+                </Flex>
+                <Divider marginY="20px" />
+                <HStack spacing={4}>
+                  <Box
+                    padding="10px"
+                    borderWidth="1px"
+                    borderRadius="md"
+                    flex="1"
+                    backgroundColor="rgba(0, 0, 0, 0.05)"
+                  >
+                    <Heading size="md" marginBottom="10px">Members</Heading>
+                    <VStack align="start">
+                      {group.members.map((member, index) => (
+                        <Text key={index}>{member}</Text>
+                      ))}
+                    </VStack>
+                  </Box>
+                  <Box
+                    padding="10px"
+                    borderWidth="1px"
+                    borderRadius="md"
+                    flex="1"
+                    backgroundColor="rgba(0, 0, 0, 0.05)"
+                  >
+                    <Heading size="md" marginBottom="10px">Created On</Heading>
+                    <Text>{new Date(group.created).toLocaleDateString()}</Text>
+                  </Box>
+                  <Box
+                    padding="10px"
+                    borderWidth="1px"
+                    borderRadius="md"
+                    flex="2"
+                    backgroundColor="rgba(0, 0, 0, 0.05)"
+                  >
+                    <Heading size="md" marginBottom="10px">Description</Heading>
+                    <Text fontSize="lg">{group.description || "No description given"}</Text>
+                  </Box>
+                </HStack>
               </VStack>
-              <Box flex="3" paddingLeft="20px">
-                <Heading size="md">Description</Heading>
-                <Text fontSize="lg">{group.description || "No description given"}</Text>
-              </Box>
-            </Flex>
-            <Box mt={8}>
+            </Box>
+            <Box mt={8} width="99%">
               <Heading size="md">Baskets Component</Heading>
               <Text mt={2}>This is where the Baskets component will be placed.</Text>
               <Box overflowY="auto" maxHeight="300px" mt={4}>
@@ -147,7 +173,7 @@ function IndividualGroupPage() {
                 </VStack>
               </Box>
             </Box>
-          </VStack>
+          </>
         ) : (
           <Box padding="20px">
             <Text fontSize="lg">Group not found!</Text>

--- a/frontend/src/pages/IndividualGroupPage.tsx
+++ b/frontend/src/pages/IndividualGroupPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import {
   Box,
   Flex,
@@ -8,8 +8,12 @@ import {
   IconButton,
   Button,
   VStack,
+  HStack,
+  Input,
+  InputGroup,
+  InputLeftElement,
 } from "@chakra-ui/react";
-import { IoArrowBack } from "react-icons/io5";
+import { IoArrowBack, IoSearch, IoAddCircleOutline, IoSettingsSharp } from "react-icons/io5";
 //import "../styles/GroupPage.css";
 
 export interface Group {
@@ -26,6 +30,7 @@ function IndividualGroupPage() {
   const { groupId } = useParams<{ groupId: string }>();
   const [group, setGroup] = useState<Group | null>(null);
   const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
 
   const fetchGroup = () => {
     const promise = fetch(`http://localhost:3001/groups/${groupId}`);
@@ -66,13 +71,12 @@ function IndividualGroupPage() {
           <IconButton
             icon={<IoArrowBack />}
             aria-label="Go Back"
-            as={Link}
-            to="/groups"
+            onClick={() => navigate('/groups')}
             marginRight="10px"
           />
-          <Heading color="var(--col-secondary)" fontWeight="300" fontSize="40px">
-            Group Details
-          </Heading>
+          <Button onClick={() => navigate('/groups')} variant="link" leftIcon={<IoArrowBack />}>
+            Go Back
+          </Button>
         </Flex>
       </Flex>
 
@@ -89,8 +93,20 @@ function IndividualGroupPage() {
           </Box>
         ) : group ? (
           <VStack align="stretch" spacing={4}>
-            <Heading size="lg">{group.groupName}</Heading>
-            <Text fontSize="lg">{group.description || "No description given"}</Text>
+            <Flex justifyContent="space-between" alignItems="center">
+              <Flex alignItems="center">
+                <Heading size="lg" marginRight="10px">{group.groupName}</Heading>
+                <Text fontSize="lg">{group.description || "No description given"}</Text>
+              </Flex>
+              <HStack>
+                <IconButton icon={<IoAddCircleOutline />} aria-label="Add" />
+                <IconButton icon={<IoSettingsSharp />} aria-label="Settings" />
+              </HStack>
+            </Flex>
+            <InputGroup width="300px" marginY="20px">
+              <InputLeftElement pointerEvents="none" children={<IoSearch />} />
+              <Input placeholder="Search in group" />
+            </InputGroup>
             <Box>
               <Heading size="md">Members</Heading>
               <VStack align="start">
@@ -103,13 +119,28 @@ function IndividualGroupPage() {
               <Heading size="md">Created On</Heading>
               <Text>{new Date(group.created).toLocaleDateString()}</Text>
             </Box>
-            <Button as={Link} to={`/groups/edit/${group._id}`} colorScheme="teal" width="200px" mt={4}>
-              Edit Group
-            </Button>
+            <Box mt={4}>
+              <Button as={Link} to={`/groups/edit/${group._id}`} colorScheme="teal" width="200px">
+                Edit Group
+              </Button>
+            </Box>
             <Box mt={8}>
-              {/* Placeholder for Baskets component */}
               <Heading size="md">Baskets Component</Heading>
-              <Text>This is where the Baskets component will be placed.</Text>
+              <Text mt={2}>This is where the Baskets component will be placed.</Text>
+              <Box overflowY="auto" maxHeight="300px" mt={4}>
+                {/* Replace with actual basket items */}
+                <VStack spacing={4} align="stretch">
+                  <Box padding="10px" borderWidth="1px" borderRadius="md">
+                    Basket Item 1
+                  </Box>
+                  <Box padding="10px" borderWidth="1px" borderRadius="md">
+                    Basket Item 2
+                  </Box>
+                  <Box padding="10px" borderWidth="1px" borderRadius="md">
+                    Basket Item 3
+                  </Box>
+                </VStack>
+              </Box>
             </Box>
           </VStack>
         ) : (

--- a/frontend/src/pages/IndividualGroupPage.tsx
+++ b/frontend/src/pages/IndividualGroupPage.tsx
@@ -27,7 +27,9 @@ function IndividualGroupPage() {
 
   const fetchGroup = async () => {
     try {
-      const fetchedGroup = await fetch(`http://localhost:3001/groups/${groupId}`);
+      const fetchedGroup = await fetch(
+        `http://localhost:3001/groups/${groupId}`,
+      );
       if (fetchedGroup.ok) {
         const data = await fetchedGroup.json();
         setGroup(data);
@@ -51,7 +53,7 @@ function IndividualGroupPage() {
           } else {
             throw new Error(`Failed to fetch user: ${res.statusText}`);
           }
-        })
+        }),
       );
       setMembers(fetchedMembers);
     } catch (err) {
@@ -82,7 +84,11 @@ function IndividualGroupPage() {
         bgGradient="linear(t-b, rgba(0,0,0,0) 10%, var(--col-secondary) 30%, var(--col-secondary) 70%, rgba(0,0,0,0) 90%)"
         flexWrap="wrap"
       >
-        <Button onClick={() => navigate('/groups')} variant="link" leftIcon={<IoArrowBack />}>
+        <Button
+          onClick={() => navigate("/groups")}
+          variant="link"
+          leftIcon={<IoArrowBack />}
+        >
           Go Back
         </Button>
         <Flex alignItems="center" flexWrap="wrap" mt={{ base: 4, md: 0 }}>
@@ -94,7 +100,7 @@ function IndividualGroupPage() {
             />
           </InputGroup>
           <Button
-            onClick={() => console.log('Send Invite clicked')}
+            onClick={() => console.log("Send Invite clicked")}
             bg="teal"
             color="white"
             _hover={{ bg: "teal" }}
@@ -115,9 +121,7 @@ function IndividualGroupPage() {
         alignItems="center"
       >
         {loading ? (
-          <Box padding="20px">
-            Loading...
-          </Box>
+          <Box padding="20px">Loading...</Box>
         ) : group ? (
           <>
             <Box
@@ -128,8 +132,14 @@ function IndividualGroupPage() {
               backgroundColor="rgba(255, 255, 255, 0.8)"
             >
               <VStack align="stretch" spacing={4}>
-                <Flex justifyContent="center" alignItems="center" position="relative">
-                  <Heading size="2xl" textAlign="center">{group.groupName}</Heading>
+                <Flex
+                  justifyContent="center"
+                  alignItems="center"
+                  position="relative"
+                >
+                  <Heading size="2xl" textAlign="center">
+                    {group.groupName}
+                  </Heading>
                   <Button
                     bg="gray.500"
                     color="white"
@@ -149,11 +159,20 @@ function IndividualGroupPage() {
                     flex="1"
                     backgroundColor="rgba(0, 0, 0, 0.05)"
                   >
-                    <Heading size="md" marginBottom="10px">Members</Heading>
+                    <Heading size="md" marginBottom="10px">
+                      Members
+                    </Heading>
                     <VStack align="start">
                       {members.map((member) => (
-                        <HStack key={member._id.toString()} spacing={4} align="center">
-                          <Avatar name={member.username} src={`http://localhost:3001/${member._id}/avatar`} />
+                        <HStack
+                          key={member._id.toString()}
+                          spacing={4}
+                          align="center"
+                        >
+                          <Avatar
+                            name={member.username}
+                            src={`http://localhost:3001/${member._id}/avatar`}
+                          />
                           <Text>{member.username}</Text>
                         </HStack>
                       ))}
@@ -166,7 +185,9 @@ function IndividualGroupPage() {
                     flex="1"
                     backgroundColor="rgba(0, 0, 0, 0.05)"
                   >
-                    <Heading size="md" marginBottom="10px">Created On</Heading>
+                    <Heading size="md" marginBottom="10px">
+                      Created On
+                    </Heading>
                     <Text>{new Date(group.created).toLocaleDateString()}</Text>
                   </Box>
                   <Box
@@ -176,15 +197,21 @@ function IndividualGroupPage() {
                     flex="2"
                     backgroundColor="rgba(0, 0, 0, 0.05)"
                   >
-                    <Heading size="md" marginBottom="10px">Description</Heading>
-                    <Text fontSize="lg">{group.description || "No description given"}</Text>
+                    <Heading size="md" marginBottom="10px">
+                      Description
+                    </Heading>
+                    <Text fontSize="lg">
+                      {group.description || "No description given"}
+                    </Text>
                   </Box>
                 </HStack>
               </VStack>
             </Box>
             <Box mt={8} width="99%">
               <Heading size="md">Baskets Component</Heading>
-              <Text mt={2}>This is where the Baskets component will be placed.</Text>
+              <Text mt={2}>
+                This is where the Baskets component will go!
+              </Text>
               <Box overflowY="auto" maxHeight="300px" mt={4}>
                 {/* Replace with actual basket items */}
                 <VStack spacing={4} align="stretch">

--- a/frontend/src/pages/IndividualGroupPage.tsx
+++ b/frontend/src/pages/IndividualGroupPage.tsx
@@ -80,12 +80,13 @@ function IndividualGroupPage() {
         borderBottom="2px solid"
         borderColor="rgba(100, 100, 100, 0.8)"
         bgGradient="linear(t-b, rgba(0,0,0,0) 10%, var(--col-secondary) 30%, var(--col-secondary) 70%, rgba(0,0,0,0) 90%)"
+        flexWrap="wrap"
       >
         <Button onClick={() => navigate('/groups')} variant="link" leftIcon={<IoArrowBack />}>
           Go Back
         </Button>
-        <Flex alignItems="center">
-          <InputGroup width="300px" marginRight="20px">
+        <Flex alignItems="center" flexWrap="wrap" mt={{ base: 4, md: 0 }}>
+          <InputGroup width={{ base: "100%", md: "300px" }} marginRight="20px">
             <InputLeftElement pointerEvents="none" children={<IoSearch />} />
             <Input
               placeholder="Search in group"
@@ -98,6 +99,7 @@ function IndividualGroupPage() {
             color="white"
             _hover={{ bg: "teal" }}
             marginRight="10px"
+            mt={{ base: 2, md: 0 }}
           >
             Send Invite
           </Button>

--- a/frontend/src/pages/IndividualGroupPage.tsx
+++ b/frontend/src/pages/IndividualGroupPage.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import {
+  Box,
+  Flex,
+  Heading,
+  Text,
+  IconButton,
+  Button,
+  VStack,
+} from "@chakra-ui/react";
+import { IoArrowBack } from "react-icons/io5";
+//import "../styles/GroupPage.css";
+
+export interface Group {
+  groupName: string;
+  _id: string;
+  privateGroup: boolean;
+  description: string;
+  members: string[];
+  baskets: string[];
+  created: Date;
+}
+
+function IndividualGroupPage() {
+  const { groupId } = useParams<{ groupId: string }>();
+  const [group, setGroup] = useState<Group | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchGroup = () => {
+    const promise = fetch(`http://localhost:3001/groups/${groupId}`);
+    return promise;
+  };
+
+  useEffect(() => {
+    fetchGroup()
+      .then((res) => res.json())
+      .then((data) => {
+        setGroup(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.log(`Terrible error occurred! ${err}`);
+      });
+  }, [groupId]);
+
+  return (
+    <Box
+      width="100vw"
+      height="100vh"
+      display="flex"
+      flexDirection="column"
+      overflow="hidden"
+      backgroundColor="var(--col-bright)"
+    >
+      {/* Header */}
+      <Flex
+        justifyContent="space-between"
+        alignItems="center"
+        padding="10px 20px"
+        borderBottom="2px solid"
+        borderColor="rgba(100, 100, 100, 0.8)"
+        bgGradient="linear(to-r, rgba(0,0,0,0) 10%, var(--col-secondary) 30%, var(--col-secondary) 70%, rgba(0,0,0,0) 90%)"
+      >
+        <Flex alignItems="center">
+          <IconButton
+            icon={<IoArrowBack />}
+            aria-label="Go Back"
+            as={Link}
+            to="/groups"
+            marginRight="10px"
+          />
+          <Heading color="var(--col-secondary)" fontWeight="300" fontSize="40px">
+            Group Details
+          </Heading>
+        </Flex>
+      </Flex>
+
+      {/* Main Content */}
+      <Flex
+        flexDirection="column"
+        padding="20px"
+        flex="1"
+        overflowY="auto"
+      >
+        {loading ? (
+          <Box padding="20px">
+            Loading...
+          </Box>
+        ) : group ? (
+          <VStack align="stretch" spacing={4}>
+            <Heading size="lg">{group.groupName}</Heading>
+            <Text fontSize="lg">{group.description || "No description given"}</Text>
+            <Box>
+              <Heading size="md">Members</Heading>
+              <VStack align="start">
+                {group.members.map((member, index) => (
+                  <Text key={index}>{member}</Text>
+                ))}
+              </VStack>
+            </Box>
+            <Box>
+              <Heading size="md">Created On</Heading>
+              <Text>{new Date(group.created).toLocaleDateString()}</Text>
+            </Box>
+            <Button as={Link} to={`/groups/edit/${group._id}`} colorScheme="teal" width="200px" mt={4}>
+              Edit Group
+            </Button>
+            <Box mt={8}>
+              {/* Placeholder for Baskets component */}
+              <Heading size="md">Baskets Component</Heading>
+              <Text>This is where the Baskets component will be placed.</Text>
+            </Box>
+          </VStack>
+        ) : (
+          <Box padding="20px">
+            <Text fontSize="lg">Group not found!</Text>
+          </Box>
+        )}
+      </Flex>
+    </Box>
+  );
+}
+
+export default IndividualGroupPage;

--- a/frontend/src/pages/IndividualGroupPage.tsx
+++ b/frontend/src/pages/IndividualGroupPage.tsx
@@ -27,14 +27,14 @@ function IndividualGroupPage() {
 
   const fetchGroup = async () => {
     try {
-      const res = await fetch(`http://localhost:3001/groups/${groupId}`);
-      if (res.ok) {
-        const data = await res.json();
+      const fetchedGroup = await fetch(`http://localhost:3001/groups/${groupId}`);
+      if (fetchedGroup.ok) {
+        const data = await fetchedGroup.json();
         setGroup(data);
         fetchMembers(data.members);
         setLoading(false);
       } else {
-        throw new Error(`Failed to fetch group: ${res.statusText}`);
+        throw new Error(`Failed to fetch group: ${fetchedGroup.statusText}`);
       }
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Developer: Sofija Dimitrijevic

Closes #34 

### Pull Request Summary
Finally finished layout for individual group page, with some functionality (displays the group's information when you click on it, back button takes you back to the groups page). Made placeholder for basket component. Still using chakra ui so if we want this to have the same design as the groups page Jonathan imma need you to help me with css :D
### Modifications

Created IndividualGroupPage file

### Testing Considerations

I need to test this more formally still, but just by using it the page works well when clicking on any of our current groups (displays all the correct information). Still need to connect to IUsers as display the usernames of the users in the groups and not just the id's. Works fine when changing screen sizes.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="1440" alt="Screenshot 2024-05-25 at 1 08 10 AM" src="https://github.com/Gather307/Gather/assets/113939891/85935800-7c97-400b-ac48-b00559f8f74f">
<img width="639" alt="Screenshot 2024-05-25 at 1 09 09 AM" src="https://github.com/Gather307/Gather/assets/113939891/a17b4f8e-431c-49f1-a36e-61e509fca48e">

