### PR TITLE
Add baskets to individual group page

### DIFF
--- a/backend/routes/basketRoutes.ts
+++ b/backend/routes/basketRoutes.ts
@@ -8,29 +8,15 @@ const router = express.Router();
 router.get("/", async (req: Request, res: Response) => {
   connectDB();
   try {
-    const users = await Basket.find({});
-    if (users.length === 0) {
-      res.status(404).send("No baskets found"); // Return a 404 status code if no users are found
+    const baskets = await Basket.find({});
+    if (baskets.length === 0) {
+      res.status(404).send("No baskets found"); // Return a 404 status code if no baskets are found
     } else {
-      res.send(users); // Return the found users
+      res.send(baskets); // Return the found baskets
     }
   } catch (error) {
     res.status(500).send("Internal Server Error"); // Handle any unexpected errors
   }
-});
-router.get("/:bid", async (req: Request, res: Response) => {
-  connectDB();
-  // Use findById correctly with the id parameter from the request
-  const basket = await Basket.findById(req.params.bid).maxTimeMS(2000);
-
-  // Check if group is null or undefined
-  if (!basket) {
-    return res.status(404).send("No basket found."); // Use return to exit the function after sending the response
-  }
-
-  // Send the found user
-  res.send(basket);
-  console.log("Sent Group");
 });
 
 router.get("/:basketid", async (req: Request, res: Response) => {
@@ -43,30 +29,25 @@ router.get("/:basketid", async (req: Request, res: Response) => {
 
     // Check if basket is null or undefined
     if (!basketById) {
-      return res.status(404).send("No basket found"); // Use return to exit the function after sending the response
-    }
-
-    // Send the found user
-    res.send(basketById);
-    console.log("Sent Basket:", basketById);
-  } catch (error) {
-    console.log("Now trying to find by BasketName");
-    try {
+      // If not found by ObjectId, try to find by basketName
       const basketsByName = await Basket.find({
         basketName: req.params.basketid,
       });
-      console.log(basketsByName);
-      if (!basketsByName) {
+
+      if (!basketsByName.length) {
         return res.status(404).send("No baskets found"); // Use return to exit the function after sending the response
       }
 
-      // Send the found user
-      res.send(basketsByName);
-      console.log("Sent Baskets", basketsByName);
-    } catch (error) {
-      console.error("Error fetching basket:", error); // Log the error for debugging
-      res.status(500).send("Internal Server Error");
+      // Send the found baskets
+      return res.send(basketsByName);
     }
+
+    // Send the found basket by ObjectId
+    res.send(basketById);
+    console.log("Sent Basket:", basketById);
+  } catch (error) {
+    console.error("Error fetching basket:", error); // Log the error for debugging
+    res.status(500).send("Internal Server Error");
   }
 });
 
@@ -98,9 +79,9 @@ router.post("/", async (req: Request, res: Response) => {
 });
 
 router.patch("/:id", async (req: Request, res: Response) => {
-  // Get user ID from URL
+  // Get basket ID from URL
   const { id } = req.params;
-  const updatedData: Partial<IBasket> = req.body; //Not a full update only partial
+  const updatedData: Partial<IBasket> = req.body; // Not a full update, only partial
 
   try {
     connectDB();
@@ -127,7 +108,7 @@ router.delete("/:id", async (req: Request, res: Response) => {
     const basket = await Basket.findByIdAndDelete(id);
 
     if (!basket) {
-      return res.status(404).send({ message: "basket not found" });
+      return res.status(404).send({ message: "Basket not found" });
     }
 
     res.status(200).send({ message: "Basket Deleted Successfully", basket });

--- a/frontend/src/components/Basket.tsx
+++ b/frontend/src/components/Basket.tsx
@@ -13,6 +13,7 @@ import BasketItem from "./BasketItem";
 import "../styles/Basket.css";
 
 export interface Basket {
+  _id: string; // added id
   basketName: string;
   description: string;
   memberIds: string[];
@@ -33,12 +34,12 @@ const BasketComp = ({ basketId, stateObj, isOwnerView }: Props) => {
     isErrored: false,
   });
 
-  const fetchItem = () => {
+  const fetchBasket = () => {
     return fetch(`http://localhost:3001/baskets/${basketId}`);
   };
 
   useEffect(() => {
-    fetchItem()
+    fetchBasket()
       .then((res) =>
         res.status === 200
           ? res.json()
@@ -46,6 +47,7 @@ const BasketComp = ({ basketId, stateObj, isOwnerView }: Props) => {
       )
       .then((data) => {
         setBasket({
+          _id: data._id, // added id
           basketName: data.basketName,
           description: data.description,
           itemIds: data.items,

--- a/frontend/src/components/Basket.tsx
+++ b/frontend/src/components/Basket.tsx
@@ -43,7 +43,7 @@ const BasketComp = ({ basketId, stateObj, isOwnerView }: Props) => {
       .then((res) =>
         res.status === 200
           ? res.json()
-          : Promise.reject(`Error code ${res.status}`),
+          : Promise.reject(`Error code ${res.status}`)
       )
       .then((data) => {
         setBasket({
@@ -56,7 +56,7 @@ const BasketComp = ({ basketId, stateObj, isOwnerView }: Props) => {
         });
       })
       .catch((err) => {
-        console.log("Terrible error occured!", err);
+        console.log("Error: ", err);
         setError({
           msg: err,
           isErrored: true,
@@ -171,7 +171,7 @@ const BasketComp = ({ basketId, stateObj, isOwnerView }: Props) => {
           <Button>ADD ITEM</Button>
         </Flex>
         <Divider borderColor="black" marginTop="1%" />
-        <VStack>
+        <VStack spacing="5px">
           {basketObj.itemIds !== undefined ? (
             basketObj.itemIds?.map((item) => {
               return (

--- a/frontend/src/components/BasketItem.tsx
+++ b/frontend/src/components/BasketItem.tsx
@@ -33,7 +33,7 @@ const BasketItem = ({ itemId, basketMemberView }: Props) => {
       .then((res) =>
         res.status === 200
           ? res.json()
-          : Promise.reject(`Error code ${res.status}`),
+          : Promise.reject(`Error code ${res.status}`)
       )
       .then((data) => {
         setItem({
@@ -62,7 +62,7 @@ const BasketItem = ({ itemId, basketMemberView }: Props) => {
   }
 
   return (
-    <Box w="100%" overflow="hidden" margin="1rem" className="b-item">
+    <Box w="100%" overflow="hidden" margin="0.5rem" className="b-item">
       {loading ? (
         <Flex>
           <Box>

--- a/frontend/src/pages/IndividualGroupPage.tsx
+++ b/frontend/src/pages/IndividualGroupPage.tsx
@@ -241,7 +241,7 @@ function IndividualGroupPage() {
                         key={basket.basketName}
                         basketId={basket._id}
                         stateObj={{ user: members, token: "your-token-here" }}
-                        isOwnerView={false} // Adjust this according to your logic
+                        isOwnerView={false} // Adjust this
                       />
                     ))}
                   </VStack>

--- a/frontend/src/pages/IndividualGroupPage.tsx
+++ b/frontend/src/pages/IndividualGroupPage.tsx
@@ -29,7 +29,9 @@ function IndividualGroupPage() {
 
   const fetchGroup = async () => {
     try {
-      const fetchedGroup = await fetch(`http://localhost:3001/groups/${groupId}`);
+      const fetchedGroup = await fetch(
+        `http://localhost:3001/groups/${groupId}`
+      );
       if (fetchedGroup.ok) {
         const data = await fetchedGroup.json();
         setGroup(data);
@@ -54,7 +56,7 @@ function IndividualGroupPage() {
           } else {
             throw new Error(`Failed to fetch user: ${res.statusText}`);
           }
-        }),
+        })
       );
       setMembers(fetchedMembers);
     } catch (err) {
@@ -72,7 +74,7 @@ function IndividualGroupPage() {
           } else {
             throw new Error(`Failed to fetch basket: ${res.statusText}`);
           }
-        }),
+        })
       );
       setBaskets(fetchedBaskets);
     } catch (err) {
@@ -237,7 +239,7 @@ function IndividualGroupPage() {
                     {baskets.map((basket) => (
                       <BasketComp
                         key={basket.basketName}
-                        basketId={basket.basketName}
+                        basketId={basket._id}
                         stateObj={{ user: members, token: "your-token-here" }}
                         isOwnerView={false} // Adjust this according to your logic
                       />

--- a/frontend/src/pages/IndividualGroupPage.tsx
+++ b/frontend/src/pages/IndividualGroupPage.tsx
@@ -17,23 +17,24 @@ import {
 import { IoArrowBack, IoSearch } from "react-icons/io5";
 import { IGroup } from "../../../backend/models/groupSchema";
 import { IUser } from "../../../backend/models/userSchema";
+import BasketComp, { Basket } from "../components/Basket";
 
 function IndividualGroupPage() {
   const { groupId } = useParams<{ groupId: string }>();
   const [group, setGroup] = useState<IGroup | null>(null);
   const [loading, setLoading] = useState(true);
   const [members, setMembers] = useState<IUser[]>([]);
+  const [baskets, setBaskets] = useState<Basket[]>([]);
   const navigate = useNavigate();
 
   const fetchGroup = async () => {
     try {
-      const fetchedGroup = await fetch(
-        `http://localhost:3001/groups/${groupId}`,
-      );
+      const fetchedGroup = await fetch(`http://localhost:3001/groups/${groupId}`);
       if (fetchedGroup.ok) {
         const data = await fetchedGroup.json();
         setGroup(data);
         fetchMembers(data.members);
+        fetchBaskets(data.baskets);
         setLoading(false);
       } else {
         throw new Error(`Failed to fetch group: ${fetchedGroup.statusText}`);
@@ -56,6 +57,24 @@ function IndividualGroupPage() {
         }),
       );
       setMembers(fetchedMembers);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const fetchBaskets = async (basketIds: string[]) => {
+    try {
+      const fetchedBaskets = await Promise.all(
+        basketIds.map(async (basketId) => {
+          const res = await fetch(`http://localhost:3001/baskets/${basketId}`);
+          if (res.ok) {
+            return res.json();
+          } else {
+            throw new Error(`Failed to fetch basket: ${res.statusText}`);
+          }
+        }),
+      );
+      setBaskets(fetchedBaskets);
     } catch (err) {
       console.error(err);
     }
@@ -133,7 +152,7 @@ function IndividualGroupPage() {
               width="99%"
               padding="20px"
               borderWidth="1px"
-              borderRadius="md"
+              borderRadius="2xl"
               backgroundColor="rgba(255, 255, 255, 0.8)"
             >
               <VStack align="stretch" spacing={4}>
@@ -211,23 +230,20 @@ function IndividualGroupPage() {
                   </Box>
                 </HStack>
               </VStack>
-            </Box>
-            <Box mt={8} width="99%">
-              <Heading size="md">Baskets Component</Heading>
-              <Text mt={2}>This is where the Baskets component will go!</Text>
-              <Box overflowY="auto" maxHeight="300px" mt={4}>
-                {/* Replace with actual basket items */}
-                <VStack spacing={4} align="stretch">
-                  <Box padding="10px" borderWidth="1px" borderRadius="md">
-                    Basket Item 1
-                  </Box>
-                  <Box padding="10px" borderWidth="1px" borderRadius="md">
-                    Basket Item 2
-                  </Box>
-                  <Box padding="10px" borderWidth="1px" borderRadius="md">
-                    Basket Item 3
-                  </Box>
-                </VStack>
+              <Box mt={8} width="99%">
+                <Heading size="xl">Baskets</Heading>
+                <Box overflowY="auto" maxHeight="300px" mt={4}>
+                  <VStack spacing={4} align="stretch">
+                    {baskets.map((basket) => (
+                      <BasketComp
+                        key={basket.basketName}
+                        basketId={basket.basketName}
+                        stateObj={{ user: members, token: "your-token-here" }}
+                        isOwnerView={false} // Adjust this according to your logic
+                      />
+                    ))}
+                  </VStack>
+                </Box>
               </Box>
             </Box>
           </>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -4,7 +4,6 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
 
   font-synthesis: none;


### PR DESCRIPTION
## Developer: {Full Name}

Closes #116 

### Pull Request Summary

Basket components that are associated with a group now show up on each individual group page

### Modifications

Modified IndividualGroupPage, made fetchBaskets function, added the baskets fetched to the basket placeholder on the page.

### Testing Considerations

Tested that it correctly renders for general cases (zero baskets, one basket, more than one basket) (will need to write actual cypress tests for this)

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
<img width="1440" alt="Screenshot 2024-05-29 at 12 46 06 AM" src="https://github.com/Gather307/Gather/assets/113939891/762759ca-872b-4290-af3a-2b2d2b7c44eb">

https://github.com/Gather307/Gather/assets/113939891/1925111a-41f4-4d9b-9995-1d32f644067f

