### PR TITLE
Group page responsive display

### DIFF
--- a/frontend/src/components/BasketItem.tsx
+++ b/frontend/src/components/BasketItem.tsx
@@ -35,7 +35,7 @@ const BasketItem = ({ itemId, bid, basketMemberView }: Props) => {
       .then((res) =>
         res.status === 200
           ? res.json()
-          : Promise.reject(`Error code ${res.status}`),
+          : Promise.reject(`Error code ${res.status}`)
       )
       .then((data) => {
         setItem(data);
@@ -54,7 +54,9 @@ const BasketItem = ({ itemId, bid, basketMemberView }: Props) => {
   const removeItem = async (item: IItem) => {
     console.log(item);
     deleteItemWithBasketString(item, bid);
-    window.location.reload();
+    setTimeout(() => {
+      window.location.reload();
+    }, 500);
   };
 
   if (!basketMemberView && item?.isPrivate) {

--- a/frontend/src/components/CompactGroup.tsx
+++ b/frontend/src/components/CompactGroup.tsx
@@ -14,8 +14,6 @@ interface Props {
 
 const CompactGroupV1 = ({
   group,
-  width,
-  height,
   corners = [false, false, false, false],
 }: Props) => {
   const [memberNames, setMemberNames] = useState<string[]>([]);
@@ -34,8 +32,8 @@ const CompactGroupV1 = ({
 
   return (
     <Box
-      width={width}
-      height={height}
+      aspectRatio={1 / 1}
+      minWidth="100%"
       borderRadius={`${corners[0] ? "0%" : "20%"} ${
         corners[1] ? "0%" : "20%"
       } ${corners[2] ? "0%" : "20%"} ${corners[3] ? "0%" : "20%"}`}
@@ -98,7 +96,7 @@ const CompactGroupV1 = ({
           <VStack
             justifyContent="end"
             spacing="5px"
-            display={{ base: "none", md: "flex", lg: "none" }}
+            display={{ base: "flex", lg: "none" }}
           >
             <Box
               width="30px"

--- a/frontend/src/components/CompactGroup.tsx
+++ b/frontend/src/components/CompactGroup.tsx
@@ -65,7 +65,11 @@ const CompactGroupV1 = ({
             height="75px"
             name={memberNames.length > 0 ? memberNames[0] : ""}
           />
-          <VStack justifyContent="end" spacing="5px">
+          <VStack
+            justifyContent="end"
+            spacing="5px"
+            display={{ base: "none", lg: "flex" }}
+          >
             <Text textAlign="center" fontSize="0.8rem">
               Created {new Date(group.created).toLocaleDateString()}
             </Text>
@@ -90,6 +94,23 @@ const CompactGroupV1 = ({
                 ) : undefined}
               </HStack>
             ) : undefined}
+          </VStack>
+          <VStack
+            justifyContent="end"
+            spacing="5px"
+            display={{ base: "none", md: "flex", lg: "none" }}
+          >
+            <Box
+              width="30px"
+              height="30px"
+              borderRadius="15px"
+              backgroundColor="darkgray"
+              display="flex"
+              justifyContent="center"
+              alignItems="center"
+            >
+              +{group.members ? group.members.length - 1 : ""}
+            </Box>
           </VStack>
         </HStack>
       </VStack>

--- a/frontend/src/pages/IndividualGroupPage.tsx
+++ b/frontend/src/pages/IndividualGroupPage.tsx
@@ -62,7 +62,7 @@ const IndividualGroupPage: React.FC<Props> = ({
           } else {
             throw new Error(`Failed to fetch friends: ${res.statusText}`);
           }
-        }),
+        })
       );
 
       setFriends(fetchedFriends);
@@ -106,21 +106,16 @@ const IndividualGroupPage: React.FC<Props> = ({
   };
 
   useEffect(() => {
-    console.log(`Loading: ${loading}`);
-
     if (!localStorage.getItem("token")) {
       navigate("/login");
     }
     if (groupId) {
       fetchGroup(String(groupId))
         .then((group) => {
-          console.log(`Fetched group: ${group}`);
           fetchGroupMembers(group as IGroup)
             .then(() => {
-              console.log(`Fetched group members: ${members}`);
               fetchBaskets(group as IGroup)
                 .then(() => {
-                  console.log(`Fetched group baskets: ${groupBaskets}`);
                   setLoading(false);
                 })
                 .catch((err) => {
@@ -138,7 +133,7 @@ const IndividualGroupPage: React.FC<Props> = ({
   }, [loading]);
 
   const dateObj = group ? new Date(group?.created) : undefined;
-  
+
   return (
     <Box
       width="100vw"
@@ -276,9 +271,7 @@ const IndividualGroupPage: React.FC<Props> = ({
                       <Heading size="md" marginBottom="10px">
                         Created On
                       </Heading>
-                      <Text>
-                        {dateObj ? dateObj.toString() : ""}
-                      </Text>
+                      <Text>{dateObj ? dateObj.toString() : ""}</Text>
                     </Box>
                     <Box
                       padding="10px"
@@ -322,21 +315,15 @@ const IndividualGroupPage: React.FC<Props> = ({
                 <Box maxHeight="300px" mt={4}>
                   <VStack spacing={4} align="stretch" paddingBottom="30px">
                     {groupBaskets && members ? (
-                      groupBaskets.map(
-                        (basket) => (
-                          console.log(group),
-                          console.log(basket),
-                          (
-                            <BasketComp
-                              key={String(basket._id)}
-                              basketId={String(basket._id)}
-                              groupMembers={members}
-                              LoggedInUser={LoggedInUser}
-                              groupId={String(groupId)}
-                            />
-                          )
-                        ),
-                      )
+                      groupBaskets.map((basket) => (
+                        <BasketComp
+                          key={String(basket._id)}
+                          basketId={String(basket._id)}
+                          groupMembers={members}
+                          LoggedInUser={LoggedInUser}
+                          groupId={String(groupId)}
+                        />
+                      ))
                     ) : (
                       <Text>No baskets available</Text>
                     )}

--- a/frontend/src/pages/MyGroupsPage.tsx
+++ b/frontend/src/pages/MyGroupsPage.tsx
@@ -8,6 +8,7 @@ import {
   HStack,
   Heading,
   Icon,
+  useBreakpointValue,
 } from "@chakra-ui/react";
 import SkeletonGroup from "../components/SkeletonGroup";
 import { IoIosSwap } from "react-icons/io";
@@ -38,7 +39,17 @@ const GroupPage: React.FC<Props> = ({
   const [groupList, setGroupList] = useState<IGroup[]>([]);
   const [filteredGroups, setFilteredGroups] = useState<IGroup[]>([]);
   const [selectedPage, setSelectedPage] = useState(1);
-  const gridDims = [2, 4];
+  let gridDims = useBreakpointValue(
+    {
+      sm: [2, 2],
+      lg: [2, 3],
+      xl: [2, 4],
+      base: [12, 1],
+      "2xl": [3, 6],
+    },
+    { fallback: "base", ssr: false }
+  );
+  gridDims = gridDims === undefined ? [12, 1] : gridDims;
   const skelIds: number[] = [];
   const navigate = useNavigate();
   for (let i = 0; i < gridDims[0] * gridDims[1]; i++) {
@@ -53,8 +64,8 @@ const GroupPage: React.FC<Props> = ({
       const lowerQuery = input.toLowerCase();
       setFilteredGroups(
         groupList.filter((group) =>
-          group.groupName.toLowerCase().includes(lowerQuery),
-        ),
+          group.groupName.toLowerCase().includes(lowerQuery)
+        )
       );
     }
   };
@@ -168,7 +179,7 @@ const GroupPage: React.FC<Props> = ({
             const currentPage = Math.floor(ind / (gridDims[0] * gridDims[1]));
             if (currentPage + 1 != selectedPage) return null;
             const row = Math.floor(
-              (ind % (gridDims[1] * gridDims[0])) / gridDims[1],
+              (ind % (gridDims[1] * gridDims[0])) / gridDims[1]
             );
             const col = ind % gridDims[1];
             return (
@@ -191,7 +202,7 @@ const GroupPage: React.FC<Props> = ({
             const currentPage = Math.floor(ind / (gridDims[0] * gridDims[1]));
             if (currentPage + 1 != selectedPage) return null;
             const row = Math.floor(
-              (ind % (gridDims[1] * gridDims[0])) / gridDims[1],
+              (ind % (gridDims[1] * gridDims[0])) / gridDims[1]
             );
             const col = ind % gridDims[1];
             return (

--- a/frontend/src/pages/MyGroupsPage.tsx
+++ b/frontend/src/pages/MyGroupsPage.tsx
@@ -45,7 +45,6 @@ const GroupPage: React.FC<Props> = ({
       lg: [2, 3],
       xl: [2, 4],
       base: [12, 1],
-      "2xl": [3, 6],
     },
     { fallback: "base", ssr: false }
   );
@@ -94,7 +93,7 @@ const GroupPage: React.FC<Props> = ({
       display="block"
       width="100%"
       height="100%"
-      overflow="hidden"
+      overflow={{ base: "auto" }}
       backgroundColor="var(--col-bright)"
     >
       {/* Header flex */}
@@ -147,16 +146,19 @@ const GroupPage: React.FC<Props> = ({
           updateUser={updateState.setUser}
         />
 
-        <SearchBar
-          onSearch={searchGroups}
-          placeholder="search for groups"
-          width="500px"
-        />
+        <Box display={{ base: "none", lg: "block" }}>
+          <SearchBar
+            onSearch={searchGroups}
+            placeholder="search for groups"
+            width="500px"
+          />
+        </Box>
       </HStack>
 
       {/* Solid line b/t Header & Grid */}
       <Box
         height="2px"
+        minHeight="2px"
         margin="0px 15px"
         bgColor="rgba(100, 100, 100, 0.8)"
         bgGradient="linear(to-r, rgba(0,0,0,0) 10%, var(--col-secondary) 30%, var(--col-secondary) 70%, rgba(0,0,0,0) 90%)"
@@ -164,11 +166,21 @@ const GroupPage: React.FC<Props> = ({
 
       {/* Grid */}
       <Grid
-        templateColumns={`repeat(${gridDims[1]}, 20vw)`}
-        templateRows={`repeat(${gridDims[0]}, 20vw)`}
+        templateColumns={{
+          base: "repeat(1, 90vw)",
+          sm: "repeat(2, 40vw)",
+          lg: "repeat(3, 27vw)",
+          xl: "repeat(4, 20vw)",
+        }}
+        templateRows={{
+          base: "repeat(12, 90vw)",
+          sm: "repeat(2, 40vw)",
+          lg: "repeat(2, 27vw)",
+          xl: "repeat(2, 20vw)",
+        }}
         gap="1.5vw 3.5vw"
         width="100vw"
-        height="85%"
+        flexGrow={1}
         padding="2vw"
         justifyContent="center"
         alignItems="center"
@@ -206,7 +218,7 @@ const GroupPage: React.FC<Props> = ({
             );
             const col = ind % gridDims[1];
             return (
-              <GridItem w="100%" h="100%" key={`groupitem${ind}`}>
+              <GridItem w="100%" aspectRatio={1 / 1} key={`groupitem${ind}`}>
                 <Link to={`/groups/${group._id}`}>
                   <CompactGroupV1
                     width="100%"

--- a/frontend/src/pages/MyGroupsPage.tsx
+++ b/frontend/src/pages/MyGroupsPage.tsx
@@ -93,7 +93,8 @@ const GroupPage: React.FC<Props> = ({
       display="block"
       width="100%"
       height="100%"
-      overflow={{ base: "auto" }}
+      overflowY={{ base: "auto" }}
+      overflowX="hidden"
       backgroundColor="var(--col-bright)"
     >
       {/* Header flex */}
@@ -181,7 +182,7 @@ const GroupPage: React.FC<Props> = ({
         gap="1.5vw 3.5vw"
         width="100vw"
         flexGrow={1}
-        padding="2vw"
+        padding="1vw"
         justifyContent="center"
         alignItems="center"
       >


### PR DESCRIPTION
### Pull Request Summary

Adds responsive display to MyGroups page and (kind of) fixes page selector overlap

### Modifications

Basket.tsx: Added a timeout on the delete item function to provide enough time for processing before refresh 
MyGroups page: Added a breakpoint grid dimension value that changes by chakra media queries 
                             Changed the sizes of rows/columns of the grid based on media queries 
                             --> In turn, this forces the page selector to render below the grid, but on certain window dimensions it renders off the page causing a scroll. Not sure if we want to change that, see images i linked below 
CompactGroup: Removed avatars/dates on lower media levels and replaced with +x member count

### Screenshots/Screencast
4K display
<img width="1101" alt="Screenshot 2024-06-04 at 8 16 00 PM" src="https://github.com/Gather307/Gather/assets/113921088/e99649f7-1833-4e7f-bfe6-3d50b0a323f0">

XL Screens (1440)
<img width="1101" alt="Screenshot 2024-06-04 at 8 16 51 PM" src="https://github.com/Gather307/Gather/assets/113921088/78a38c76-bb6b-4ce0-8fd0-79d092dfb89b">

LG Screens (1080)
<img width="809" alt="Screenshot 2024-06-04 at 8 17 22 PM" src="https://github.com/Gather307/Gather/assets/113921088/4ecb4a11-8ce9-4733-9b77-542898f31cf4">

Tablets
<img width="609" alt="Screenshot 2024-06-04 at 8 17 47 PM" src="https://github.com/Gather307/Gather/assets/113921088/29a295a5-0ded-4296-81dd-49131634fa85">

Smaller (note that the search bar is gone & create button slightly overrenders text but i think this is such a small use case we should focus on other more important things fix this if we have time)
<img width="350" alt="Screenshot 2024-06-04 at 8 18 13 PM" src="https://github.com/Gather307/Gather/assets/113921088/abc67f10-b81e-49ce-9fbf-9933d87c6bcd">

I recommend pulling and checking the display on your own screen to confirm it displays how you want it to, just copy the below commands (they might work but i lowkey didn't test these so if they don't work you'll just have to do it manually)

git checkout main && git pull origin main && git checkout group-page-responsive-display

